### PR TITLE
Update Fyodor URI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -428,7 +428,7 @@ services:
     environment:
       - INFINISPAN_URL=infinispan:${INFINISPAN_PORT}
       - INFINISPAN_CLIENT_INTELLIGENCE=BASIC
-      - FYODOR_SERVICE_API=http://fyodor:${FYODOR_INTERNAL_PORT}
+      - FYODOR_SERVICE_API=http://alyson.genny.life:${FYODOR_PORT}
       - GENNY_KAFKA_URL=kafka:${KAFKA_PORT}
       - kafka.bootstrap.servers=kafka:${KAFKA_PORT}
       - GENNY_KOGITO_SERVICE_URL=http://alyson2.genny.life:${GADAQ_PORT}


### PR DESCRIPTION
Use the generic location with the FYODOR_PORT variable instead of the docker network URI.